### PR TITLE
Add unit tests for each diagram type

### DIFF
--- a/src/FluentMermaid.Tests/ClassDiagramTests.cs
+++ b/src/FluentMermaid.Tests/ClassDiagramTests.cs
@@ -1,0 +1,25 @@
+using System;
+using FluentMermaid.ClassDiagram;
+using FluentMermaid.ClassDiagram.Nodes;
+using FluentMermaid.Enums;
+using Xunit;
+
+namespace FluentMermaid.Tests;
+
+public class ClassDiagramTests
+{
+    [Fact]
+    public void Render_ShouldReturnExpectedDiagram()
+    {
+        var diagram = ClassDiagram.Create(Orientation.LeftToRight);
+        diagram.AddClass(new TypeName("Person", null), null, null);
+
+        var newline = Environment.NewLine;
+        var expected =
+            "classDiagram" + newline +
+            "direction LR" + newline +
+            "class Person" + newline;
+
+        Assert.Equal(expected, diagram.Render());
+    }
+}

--- a/src/FluentMermaid.Tests/FlowChartTests.cs
+++ b/src/FluentMermaid.Tests/FlowChartTests.cs
@@ -1,0 +1,28 @@
+using System;
+using FluentMermaid.Enums;
+using FluentMermaid.Flowchart;
+using FluentMermaid.Flowchart.Enum;
+using Xunit;
+
+namespace FluentMermaid.Tests;
+
+public class FlowChartTests
+{
+    [Fact]
+    public void Render_ShouldReturnExpectedDiagram()
+    {
+        var chart = FlowChart.Create(Orientation.LeftToRight);
+        var a = chart.TextNode("A", Shape.Circle);
+        var b = chart.TextNode("B", Shape.Circle);
+        chart.Link(a, b, Link.Arrow, "hello");
+
+        var newline = Environment.NewLine;
+        var expected =
+            "flowchart LR" + newline +
+            "id0((\"A\"))" + newline +
+            "id1((\"B\"))" + newline +
+            "id0 --> |\"hello\"| id1" + newline;
+
+        Assert.Equal(expected, chart.Render());
+    }
+}

--- a/src/FluentMermaid.Tests/FluentMermaid.Tests.csproj
+++ b/src/FluentMermaid.Tests/FluentMermaid.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../FluentMermaid/FluentMermaid.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FluentMermaid.Tests/PieChartTests.cs
+++ b/src/FluentMermaid.Tests/PieChartTests.cs
@@ -1,0 +1,23 @@
+using System;
+using FluentMermaid.PieChart;
+using Xunit;
+
+namespace FluentMermaid.Tests;
+
+public class PieChartTests
+{
+    [Fact]
+    public void Render_ShouldReturnExpectedDiagram()
+    {
+        var chart = PieChart.Create("Sales", true);
+        chart.Add("A", 1);
+
+        var newline = Environment.NewLine;
+        var expected =
+            "pie showData" + newline +
+            "title Sales" + newline +
+            "\"A\" : 1" + newline;
+
+        Assert.Equal(expected, chart.Render());
+    }
+}

--- a/src/FluentMermaid.Tests/SequenceDiagramBuilderTests.cs
+++ b/src/FluentMermaid.Tests/SequenceDiagramBuilderTests.cs
@@ -1,0 +1,39 @@
+using System;
+using FluentMermaid.SequenceDiagram;
+using FluentMermaid.SequenceDiagram.Enum;
+using Xunit;
+
+namespace FluentMermaid.Tests;
+
+public class SequenceDiagramBuilderTests
+{
+    [Fact]
+    public void AddMember_ShouldThrow_WhenNameIsNullOrWhitespace()
+    {
+        var builder = new SequenceDiagramBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.AddMember(null!, MemberType.Participant));
+        Assert.Throws<ArgumentException>(() => builder.AddMember(string.Empty, MemberType.Participant));
+        Assert.Throws<ArgumentException>(() => builder.AddMember(" ", MemberType.Participant));
+    }
+
+    [Fact]
+    public void Build_ShouldReturnExpectedDiagram()
+    {
+        var builder = new SequenceDiagramBuilder(autoNumber: true);
+        var alice = builder.AddMember("Alice", MemberType.Participant);
+        var bob = builder.AddMember("Bob", MemberType.Actor);
+
+        builder.Message(alice, bob, "Hi", MessageType.SolidArrow);
+
+        var newline = Environment.NewLine;
+        var expected =
+            "sequenceDiagram" + newline +
+            "autonumber" + newline +
+            "participant member0 as Alice" + newline +
+            "actor member1 as Bob" + newline +
+            "member0->>member1: Hi" + newline;
+
+        Assert.Equal(expected, builder.Build());
+    }
+}

--- a/src/FluentMermaid.Tests/StateDiagramTests.cs
+++ b/src/FluentMermaid.Tests/StateDiagramTests.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentMermaid.Enums;
+using FluentMermaid.StateDiagram;
+using Xunit;
+
+namespace FluentMermaid.Tests;
+
+public class StateDiagramTests
+{
+    [Fact]
+    public void Render_ShouldReturnExpectedDiagram()
+    {
+        var diagram = StateDiagramBuilder.Create(Orientation.LeftToRight);
+        var idle = diagram.AddState("Idle");
+        diagram.StartTo(idle);
+
+        var newline = Environment.NewLine;
+        var expected =
+            "stateDiagram-v2" + newline +
+            "direction LR" + newline +
+            "s0 : Idle" + newline +
+            "[*] --> s0" + newline;
+
+        Assert.Equal(expected, diagram.Render());
+    }
+}

--- a/src/FluentMermaidLibrary.sln
+++ b/src/FluentMermaidLibrary.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentMermaid", "FluentMermaid\FluentMermaid.csproj", "{557AD2F1-1C76-46F2-919E-D8AB7D599099}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentMermaid.Tests", "FluentMermaid.Tests\FluentMermaid.Tests.csproj", "{F86AD713-CFBF-4900-A63B-6ED422B20ABD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -11,6 +13,10 @@ Global
 		{557AD2F1-1C76-46F2-919E-D8AB7D599099}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{557AD2F1-1C76-46F2-919E-D8AB7D599099}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{557AD2F1-1C76-46F2-919E-D8AB7D599099}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{557AD2F1-1C76-46F2-919E-D8AB7D599099}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {557AD2F1-1C76-46F2-919E-D8AB7D599099}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F86AD713-CFBF-4900-A63B-6ED422B20ABD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F86AD713-CFBF-4900-A63B-6ED422B20ABD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F86AD713-CFBF-4900-A63B-6ED422B20ABD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F86AD713-CFBF-4900-A63B-6ED422B20ABD}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add xUnit tests covering FlowChart, ClassDiagram, PieChart and StateDiagram builders
- verify basic rendering for each diagram

## Testing
- `dotnet test src/FluentMermaid.Tests/FluentMermaid.Tests.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684001b3559c833085e89d9b4657e5ba